### PR TITLE
atob icon path

### DIFF
--- a/src/services/stash-items.js
+++ b/src/services/stash-items.js
@@ -9,6 +9,8 @@ const BASE_URL = 'https://www.pathofexile.com/character-window/get-stash-items';
 const RARE_FRAME_TYPE = 2;
 
 const getTypeFrom = ({icon}) => {
+  icon = atob(icon.split('/')[5]);
+  
   if (/\/BodyArmours\//.test(icon)) return 'bodyArmour';
   if (/\/Helmets\//.test(icon)) return 'helmet';
   if (/\/Gloves\//.test(icon)) return 'glove';


### PR DESCRIPTION
Resolves issue #31 
The address was updated, example:
`https://web.poecdn.com/gen/image/WzI1LDE0LHsiZiI6IjJESXRlbXMvQXJtb3Vycy9IZWxtZXRzL0hlbG1ldERleEludDEwIiwidyI6MiwiaCI6Miwic2NhbGUiOjF9XQ/62018602df/HelmetDexInt10.png`

Splitting the encoded section provides the following:
```
[25,14,{"f":"2DItems/Armours/Helmets/HelmetDexInt10","w":2,"h":2,"scale":1}]
```

using the existing regex over the decrypted section resolves the issue.